### PR TITLE
Switch to Buildhub2 (#6)

### DIFF
--- a/crashclouseau/buildhub.py
+++ b/crashclouseau/buildhub.py
@@ -20,8 +20,8 @@ PRODS = {'Firefox': 'firefox',
 RPRODS = {v: k for k, v in PRODS.items()}
 
 # regexp matching the correct version formats for elastic search query
-VERSION_PATS = {'nightly': r'[0-9]+\".0a1\"',
-                'beta': r'[0-9]+\".0b\"[0-9]+',
+VERSION_PATS = {'nightly': r'[0-9]+".0a1"',
+                'beta': r'[0-9]+".0b"[0-9]+',
                 'release': r'[0-9]+\.[0-9]+(\.[0-9]+)?'}
 
 

--- a/crashclouseau/buildhub.py
+++ b/crashclouseau/buildhub.py
@@ -20,9 +20,9 @@ PRODS = {'Firefox': 'firefox',
 RPRODS = {v: k for k, v in PRODS.items()}
 
 # regexp matching the correct version formats for elastic search query
-VERSION_PATS = {'nightly': '[0-9]+\".0a1\"',
-                'beta': '[0-9]+\".0b\"[0-9]+',
-                'release': '[0-9]+\.[0-9]+(\.[0-9]+)?'}
+VERSION_PATS = {'nightly': r'[0-9]+\".0a1\"',
+                'beta': r'[0-9]+\".0b\"[0-9]+',
+                'release': r'[0-9]+\.[0-9]+(\.[0-9]+)?'}
 
 
 def make_request(params, sleep, retry, callback):

--- a/crashclouseau/buildhub.py
+++ b/crashclouseau/buildhub.py
@@ -13,7 +13,7 @@ from . import utils
 from .logger import logger
 
 
-URL = 'https://buildhub.prod.mozaws.net/v1/buckets/build-hub/collections/releases/search'
+URL = 'https://buildhub.moz.tools/api/search'
 PRODS = {'Firefox': 'firefox',
          'FennecAndroid': 'fennec',
          'Thunderbird': 'thunderbird'}

--- a/crashclouseau/report_bug.py
+++ b/crashclouseau/report_bug.py
@@ -27,7 +27,7 @@ def get_bz_query(data):
     for i in findall(needle, data):
         j = data.index('\"', i + len(needle))
         if j != -1:
-            bz_url = data[i + len('href=\"') : j]
+            bz_url = data[i + len('href=\"'): j]
             if 'keywords=crash' in bz_url:
                 query = parse_qs(urlparse(bz_url).query)
                 return query


### PR DESCRIPTION
This switches build data acquisition to use Buildhub2.

I was able to run the tests, but I wasn't able to run the app. It needs a database and I don't have that set up locally. But based on other migrations I've done, I think this will work.

Fixes #6.