### PR TITLE
Support setting the authentication token for Socorro API

### DIFF
--- a/crashclouseau/__init__.py
+++ b/crashclouseau/__init__.py
@@ -5,12 +5,15 @@
 from flask import Flask, send_from_directory
 from flask_cors import CORS, cross_origin
 from flask_sqlalchemy import SQLAlchemy
+from libmozdata.socorro import Socorro
 import logging
 import os
 from . import config
 
 
 app = Flask(__name__, template_folder="../templates")
+
+Socorro.TOKEN = os.getenv("SOCORRO_TOKEN", config.get_socorro())
 
 uri = os.getenv("DATABASE_URL", config.get_database())
 # Workaround for Heroku

--- a/crashclouseau/config.py
+++ b/crashclouseau/config.py
@@ -78,6 +78,10 @@ def get_redis():
     return _get_local().get("redis", "")
 
 
+def get_socorro():
+    return _get_local().get("socorro", "")
+
+
 def get_threshold(typ, product, channel):
     return (
         _get_global()


### PR DESCRIPTION
I was informed by @gabrielesvelto that repeatedly using the `ProcessedCrash` API without authentication is restricted to approximately 200 requests. Therefore, authenticating the requests would speed up the processing of the queues by reducing the number of request retries.