### PR TITLE
Return the build ids as numbers to be consistent with Socorro

### DIFF
--- a/crashclouseau/models.py
+++ b/crashclouseau/models.py
@@ -680,7 +680,7 @@ class Signature(db.Model):
         reports_map = {
             report.id: {
                 "uuid": report.uuid,
-                "build_id": utils.get_buildid(report.buildid),
+                "build_id": int(utils.get_buildid(report.buildid)),
                 "product": report.product,
                 "channel": report.channel,
                 "signature": report.signature,


### PR DESCRIPTION
Socorro docs: https://crash-stats.mozilla.org/documentation/supersearch/api/#param-build_id

I would change it everywhere to be int (including the database) but this would be a lot of work for now.